### PR TITLE
Changes so that it works on windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,11 @@ ADD conf/apache.conf /etc/apache2/sites-available/000-default.conf
 
 RUN a2enmod rewrite
 
-ADD startScript.sh /startScript.sh
+# The printf command below creates the script /startScript.sh with the following 3 lines. 
+# #!/bin/bash
+# mv /codeigniter4 /var/www/html
+# /usr/sbin/apache2ctl -D FOREGROUND
+RUN printf "#!/bin/bash\nmv /codeigniter4 /var/www/html\n/usr/sbin/apache2ctl -D FOREGROUND" > /startScript.sh
 RUN chmod +x /startScript.sh
 
 RUN cd /var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,10 @@ services:
 #--------------------------------------------------------------------------#
 #--------------------------------------------------------------------------#
     codeigniter4:
-        image: atsanna/codeigniter4:latest
+        image: codeigniter:4.0.3
         container_name: 'codeigniter4'
+        build:
+          context: ./
         ports:
           - 80:80
         links:


### PR DESCRIPTION
It turns out that WIndows does weird things to the *sh script (I think it may add CRLF instead of preserving the LF) so what I found out the hard way was the the mv command to move the codeigniter folder into the /var/www/html foder never occurred and it must be due to the way windows decides to change LF to CRLF when I clone the repo.

So what I have done is
- create the .sh file in the dockerfile itself instead of having to use the ADD command (this makes it works on Docker Desktop on WIndows)
- Changed the docker-compose yml to just use the local build context instead.

