### PR TITLE
docs: add a parameter to stop docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker build . -t codeigniter:4.1.4
 
 start the container:
 ```
-docker container run --publish 80:80 --name ci4 -v /localfolder:/var/www/html codeigniter:4.1.4
+docker container run -it --publish 80:80 --name ci4 -v /localfolder:/var/www/html codeigniter:4.1.4
 ```
 
 ## Installation


### PR DESCRIPTION
Hi, thanks for the guide on running Code Igniter using Docker !

After spinning up the docker container with a suggested command in README.md :
```bash
docker container run --publish 80:80 --name ci4 -v /localfolder:/var/www/html codeigniter:4.1.4
```

I was not able to stop it using `ctrl + c` keys. On the contrary, passing `-it` as a parameter in the command did the job : 
```bash
docker container run -it --publish 80:80 --name ci4 -v /localfolder:/var/www/html codeigniter:4.1.4
```

Let me know your thoughts, thanks.